### PR TITLE
New configuration setting - "generateRobotsFile"

### DIFF
--- a/App_Config/Include/SitemapXML.config
+++ b/App_Config/Include/SitemapXML.config
@@ -13,6 +13,7 @@
       <sitemapVariable name="database" value="web" />
       <sitemapVariable name="sitemapConfigurationItemPath" value="/sitecore/system/Modules/Sitemap XML/Sitemap configuration" />
       <sitemapVariable name="productionEnvironment" value="false" />
+      <sitemapVariable name="generateRobotsFile" value="true" />
       <sites>
         <!-- 
       serverUrl: (optional) will be used to generate url in sitemap file. 

--- a/sitecore modules/Shell/sitemap XML/Classes/SitemapManager.cs
+++ b/sitecore modules/Shell/sitemap XML/Classes/SitemapManager.cs
@@ -108,6 +108,8 @@ namespace Sitecore.Modules.SitemapXML
 
         public void RegisterSitemapToRobotsFile()
         {
+            if (!SitemapManagerConfiguration.GenerateRobotsFile)
+                return;
 
             string robotsPath = MainUtil.MapPath(string.Concat("/", "robots.txt"));
             StringBuilder sitemapContent = new StringBuilder(string.Empty);

--- a/sitecore modules/Shell/sitemap XML/SitemapManagerConfiguration.cs
+++ b/sitecore modules/Shell/sitemap XML/SitemapManagerConfiguration.cs
@@ -84,6 +84,18 @@ namespace Sitecore.Modules.SitemapXML
                 return !string.IsNullOrEmpty(production) && (production.ToLower() == "true" || production == "1");
             }
         }
+
+        public static bool GenerateRobotsFile
+        {
+            get
+            {
+                var generateRobotsFile = GetValueByName("generateRobotsFile");
+
+                // Defaults to true if setting is missing from config
+                return string.IsNullOrEmpty(generateRobotsFile) || (generateRobotsFile.ToLower() == "true" || generateRobotsFile == "1");
+            }
+        }
+
         #endregion properties
 
         private static string GetValueByName(string name)


### PR DESCRIPTION
Our project has a large multi-site SiteCore installation (79 sites and counting...) where each site are completely different financial and legal entities and therefore required separate "robots.txt" files per site, rather than one containing references to all the different sitemaps. With this new configuration setting we can choose to generate "robots.txt" files somewhere else, we do it using a custom HttpRequestProcessor (source not included).