### PR TITLE
Added exclude by query field

### DIFF
--- a/Data/packages/Sitemap XML module.xml
+++ b/Data/packages/Sitemap XML module.xml
@@ -36,6 +36,7 @@
         <x-item>/master/sitecore/templates/Sitemap XML/Sitemap configuration/Configuration/{4D81B455-5970-4CCE-9C90-D797F19C8A00}/invariant/0</x-item>
         <x-item>/master/sitecore/templates/Sitemap XML/Sitemap configuration/Configuration/Enabled templates/{1452D535-BA8B-4A66-9A87-67D05A6E2058}/invariant/0</x-item>
         <x-item>/master/sitecore/templates/Sitemap XML/Sitemap configuration/Configuration/Exclude items/{76002E61-2397-4B4D-84B2-98C2A8468D5A}/invariant/0</x-item>
+        <x-item>/master/sitecore/templates/Sitemap XML/Sitemap configuration/Configuration/Exclude by query/{61AADE4C-2E29-4E22-A041-FDEEB6B4CFA6}/invariant/0</x-item>
         <x-item>/master/sitecore/templates/Sitemap XML/Sitemap configuration/Data/{AEEFC911-1513-4C35-B212-9299CDCA253F}/invariant/0</x-item>
         <x-item>/master/sitecore/templates/Sitemap XML/Sitemap configuration/Data/Search engines/{6BF47032-530C-4DF3-9B29-0849E0990319}/invariant/0</x-item>
         <x-item>/master/sitecore/templates/Sitemap XML/Sitemap searchengine/{122FF533-9564-4ADA-A1C8-E7B1385B89DE}/invariant/0</x-item>

--- a/Data/serialization/master/sitecore/templates/Sitemap XML/Sitemap configuration/Configuration/Exclude by query.item
+++ b/Data/serialization/master/sitecore/templates/Sitemap XML/Sitemap configuration/Configuration/Exclude by query.item
@@ -1,0 +1,65 @@
+----item----
+version: 1
+id: {61AADE4C-2E29-4E22-A041-FDEEB6B4CFA6}
+database: master
+path: /sitecore/templates/Sitemap XML/Sitemap configuration/Configuration/Exclude by query
+parent: {4D81B455-5970-4CCE-9C90-D797F19C8A00}
+name: Exclude by query
+master: {00000000-0000-0000-0000-000000000000}
+template: {455A3E98-A627-4B40-8035-E683A0331AC7}
+templatekey: Template field
+
+----field----
+field: {AB162CC0-DC80-4ABF-8871-998EE5D7BA32}
+name: Type
+key: type
+content-length: 16
+
+Single-Line Text
+----field----
+field: {BA3F86A2-4A1C-4D78-B63D-91C2779C1B5E}
+name: __Sortorder
+key: __sortorder
+content-length: 3
+
+400
+----version----
+language: en
+version: 1
+revision: 55722dad-f16e-4b91-ad2d-961f42b61a2a
+
+----field----
+field: {9541E67D-CE8C-4225-803D-33F7F29F09EF}
+name: __Short description
+key: __short description
+content-length: 75
+
+filter query is applied to items individually, and must start with "self::"
+----field----
+field: {25BED78C-4957-4165-998A-CA1B52F67497}
+name: __Created
+key: __created
+content-length: 15
+
+20140128T095331
+----field----
+field: {8CDC337E-A112-42FB-BBB4-4143751E123F}
+name: __Revision
+key: __revision
+content-length: 36
+
+55722dad-f16e-4b91-ad2d-961f42b61a2a
+----field----
+field: {D9CF14B1-FA16-4BA6-9288-E8A174D4D522}
+name: __Updated
+key: __updated
+content-length: 34
+
+20140128T105029:635265030292970515
+----field----
+field: {BADD9CF9-53E0-4D0C-BCC0-2D784C282F6A}
+name: __Updated by
+key: __updated by
+content-length: 14
+
+sitecore\admin

--- a/sitecore modules/Shell/sitemap XML/Classes/SitemapManager.cs
+++ b/sitecore modules/Shell/sitemap XML/Classes/SitemapManager.cs
@@ -268,7 +268,7 @@ namespace Sitecore.Modules.SitemapXML
         {
             string disTpls = SitemapManagerConfiguration.EnabledTemplates;
             string exclNames = SitemapManagerConfiguration.ExcludeItems;
-
+            string exclQuery = SitemapManagerConfiguration.ExcludeByQuery;
 
             Database database = Factory.GetDatabase(SitemapManagerConfiguration.WorkingDatabase);
 
@@ -286,11 +286,17 @@ namespace Sitecore.Modules.SitemapXML
             List<string> enabledTemplates = this.BuildListFromString(disTpls, '|');
             List<string> excludedNames = this.BuildListFromString(exclNames, '|');
 
-
             var selected = from itm in sitemapItems
                            where itm.Template != null && enabledTemplates.Contains(itm.Template.ID.ToString()) &&
                                     !excludedNames.Contains(itm.ID.ToString())
                            select itm;
+
+            if (!string.IsNullOrEmpty(exclQuery) && exclQuery.StartsWith("self::"))
+            {
+                selected = from itm in selected
+                           where itm.Axes.SelectSingleItem(exclQuery) == null
+                           select itm;
+            }
 
             return selected.ToList();
         }

--- a/sitecore modules/Shell/sitemap XML/SitemapManagerConfiguration.cs
+++ b/sitecore modules/Shell/sitemap XML/SitemapManagerConfiguration.cs
@@ -76,6 +76,14 @@ namespace Sitecore.Modules.SitemapXML
             }
         }
 
+        public static string ExcludeByQuery
+        {
+            get
+            {
+                return GetValueByNameFromDatabase("Exclude by query");
+            }
+        }
+
         public static bool IsProductionEnvironment
         {
             get


### PR DESCRIPTION
I added a field to the Xml configuration that will allow a user to specify a "self::" query for excluding items, instead of being required to manually select each one.

For example, this enables us to define a field on all of our content pages called "ShowInXmlSitemap", and specify the exclude query self::[not(@ShowInXmlSitemap="1")]
